### PR TITLE
fix!: use connection string for server connections, appinsights broke…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Normally setting required Instrumentation Key information would be enough.
   - Default: `process.env.APPINSIGHTS_INSTRUMENTATION_KEY || false`
   - If no `instrumentationKey` is provided module wont work
 
+### serverConnectionString
+- Type: `String`
+  - Default: `process.env.APPINSIGHTS_CONNECTION_STRING || false`
+  - If no `serverConnectionString` is provided server side wont work
+
 ### disabled
 - Type: `Boolean`
   - Default: `process.env.APPINSIGHTS_DISABLED || false`

--- a/lib/appinsights.server.js
+++ b/lib/appinsights.server.js
@@ -1,12 +1,3 @@
-import * as applicationinsights from 'applicationinsights'
-
 export default function (ctx, inject) {
-  // Inject AppInsights to the context as $appInsights
-  const config = <%= serialize(options.config) %>
-  const appInsightsServer = applicationinsights.setup(<%= serialize(options.instrumentationKey) %>)
-  applicationinsights.defaultClient.config = config
-  if (optionsServer.initialize) {
-     appInsightsServer.start()
-  }
-  inject('appInsights', applicationinsights || {})
+  inject('appInsights', ctx.req.$appInsights || {})
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -7,6 +7,7 @@ const { requestHandler, errorHandler } = require('./serverHandlers')
 module.exports = function appInsights (moduleOptions) {
   const defaults = {
     instrumentationKey: process.env.APPINSIGHTS_INSTRUMENTATION_KEY || false,
+    serverConnectionString: process.env.APPINSIGHTS_CONNECTION_STRING || false,
     disabled: process.env.APPINSIGHTS_DISABLED || false,
     initialize: process.env.APPINSIGHTS_INITIALIZE || true,
     disableClientSide: process.env.APPINSIGHTS_DISABLE_CLIENT_SIDE || false,
@@ -59,7 +60,11 @@ module.exports = function appInsights (moduleOptions) {
 
     const optionsServer = deepMerge.all([options, privateRuntimeConfig])
 
-    const appInsightsServer = AppInsights.setup(optionsServer.instrumentationKey)
+    if (!optionsServer.serverConnectionString) {
+      logger.info('Server errors will not be logged because no serverConnectionString provided')
+      return
+    }
+    const appInsightsServer = AppInsights.setup(optionsServer.serverConnectionString)
     const config = { ...AppInsights.defaultClient.config, ...optionsServer.serverConfig }
 
     AppInsights.defaultClient.config = config
@@ -74,12 +79,7 @@ module.exports = function appInsights (moduleOptions) {
     this.addPlugin({
       src: path.resolve(__dirname, 'appinsights.server.js'),
       fileName: 'appinsights.server.js',
-      mode: 'server',
-      options: {
-        instrumentationKey: optionsServer.instrumentationKey,
-        config,
-        initialize: optionsServer.initialize
-      }
+      mode: 'server'
     })
 
     this.nuxt.hook('render:setupMiddleware', app => app.use(requestHandler(appInsightsClient)))

--- a/lib/serverHandlers.js
+++ b/lib/serverHandlers.js
@@ -1,5 +1,6 @@
 const requestHandler = client => (req, res, next) => {
   client.trackRequest(req, res)
+  req.$appInsights = client
   next()
 }
 


### PR DESCRIPTION
… it in 2.2 release and use connection string for setup instead of apikey

fix: broken ssr errors on nuxt2