### PR TITLE
fix: use `lodash.template` directly to compile template

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { template } from 'lodash-es'
 const path = require('path')
 const { fileURLToPath } = require('url')
 const AppInsights = require('applicationinsights')
@@ -44,7 +46,10 @@ module.exports = defineNuxtModule({
     // Register the client plugin
     if (!options.disableClientSide) {
       addTemplate({
-        src: path.resolve(__dirname, 'appinsights-vue.js'),
+        getContents({ options }) {
+          const contents = readFileSync(path.resolve(__dirname, 'appinsights-vue.js'), 'utf-8')
+          return template(contents)({ options })
+        },
         fileName: 'appinsights-vue.js'
       })
       addPluginTemplate({

--- a/package.json
+++ b/package.json
@@ -22,13 +22,15 @@
     "nuxt": "node --inspect=0.0.0.0 node_modules/nuxt-edge/bin/nuxt test/fixture"
   },
   "dependencies": {
+    "@microsoft/applicationinsights-web": "^2.8.7",
     "@nuxt/kit": "^3.0.0-rc.10",
     "applicationinsights": "^2.3.5",
-    "@microsoft/applicationinsights-web": "^2.8.7",
-    "deepmerge": "^4.2.2"
+    "deepmerge": "^4.2.2",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@nuxtjs/eslint-config": "^6.0.1",
+    "@types/lodash-es": "^4.17.12",
     "codecov": "^3.8.2",
     "eslint": "^7.28.0",
     "jest": "^26.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2755,6 +2755,18 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash-es@^4.17.12":
+  version "4.17.12"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.12.tgz#65f6d1e5f80539aa7cfbfc962de5def0cf4f341b"
+  integrity sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.0.tgz#d774355e41f372d5350a4d0714abb48194a489c3"
+  integrity sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==
+
 "@types/minimist@^1.2.0":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
@@ -9501,6 +9513,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash._reinterpolate@^3.0.0, lodash._reinterpolate@~3.0.0:
   version "3.0.0"


### PR DESCRIPTION
We are going to be removing support for [compiling templates from disk using `lodash.template`](https://github.com/nuxt/nuxt/issues/25332) in Nuxt v4. This is a PR to move lodash usage directly into the module to avoid breaking it on Nuxt 4.

It would also be possible to avoid using it entirely, which I would _strongly_ recommend, either:
* using a custom function to handle the replacement, such as in https://github.com/nuxt-modules/color-mode/pull/240
* or moving the string interpolation logic directly into `getContents`
